### PR TITLE
Add a full_title helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  # Returns the full title on a per-page basis.
+  def full_title(page_title = '')
+    base_title = "Ruby on Rails Tutorial Sample App"
+    if page_title.empty?
+      base_title
+    else
+      page_title + " | " + base_title
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,9 @@
 module ApplicationHelper
   # Returns the full title on a per-page basis.
-  def full_title(page_title = '')
+  def full_title(page_title = "")
     base_title = "Ruby on Rails Tutorial Sample App"
-    if page_title.empty?
-      base_title
-    else
-      page_title + " | " + base_title
-    end
+    
+    return base_title if page_title.empty?
+    page_title + " | " + base_title
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
### Title
Source for Chapter 4 in "Ruby on Rails Tutorial (Rails 5)"
Link: https://www.railstutorial.org/book/rails_flavored_ruby

### Background
Training Rails

### Technical Changes
1. Add a full_title helper function to display dynamic title on pages.
If we don't provide title in page's html, the helper will show the default title "Ruby on Rails Tutorial Sample App"

### Test
Run "rails t". All Passed.

### Database Migration (Optional)
N/A